### PR TITLE
Feature: Healthchecks.io Dead-Mans Switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1004,7 @@ dependencies = [
  "config",
  "eyre",
  "futures-util",
+ "healthchecks",
  "indicatif",
  "lazy_static",
  "reqwest",
@@ -1080,6 +1090,12 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytemuck"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -1285,6 +1301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1534,7 +1559,7 @@ dependencies = [
  "sha2",
  "sha3",
  "thiserror 1.0.69",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1595,6 +1620,16 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1832,6 +1867,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "healthchecks"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9548e7d7628d6c151b6db0a245cb41a5ebe72a3d56995fb45432b457482336b8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.11",
+ "ureq",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -2356,9 +2405,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -3149,6 +3198,7 @@ version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4007,6 +4057,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,6 +4117,15 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 config = "0.15.6"
 lazy_static = "1.5.0"
 indicatif = "0.17.11"
-
+healthchecks = "3.1.7"

--- a/config.toml
+++ b/config.toml
@@ -13,3 +13,5 @@ beacon_max_retries = 12
 fallback_wait_interval = 30000 ## only applicable when fallback-mode is enabled
 
 keystore_password = "" ## will prompt if not specified here
+
+healthchecks_id = "" ## ID from healthchecks.io

--- a/config.toml
+++ b/config.toml
@@ -14,4 +14,4 @@ fallback_wait_interval = 30000 ## only applicable when fallback-mode is enabled
 
 keystore_password = "" ## will prompt if not specified here
 
-healthchecks_id = "" ## ID from healthchecks.io
+healthcheck_id = "" ## ID from healthchecks.io

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub beacon_max_retries: usize,
     pub fallback_wait_interval: Duration,
     pub keystore_password: Option<String>,
+    pub healthcheck_id: Option<String>,
 }
 
 fn build_config() -> eyre::Result<Config> {
@@ -39,6 +40,7 @@ fn build_config() -> eyre::Result<Config> {
     );
     let chain_id = cfg.get::<u64>("chain_id").unwrap_or(DEFAULT_CHAIN_ID);
     let keystore_password = cfg.get::<Option<String>>("keystore_password").unwrap_or(None);
+    let healthcheck_id = cfg.get::<Option<String>>("healthcheck_id").unwrap_or(None);
 
     Ok(Config {
         chain_id,
@@ -48,6 +50,7 @@ fn build_config() -> eyre::Result<Config> {
         beacon_max_retries,
         fallback_wait_interval,
         keystore_password,
+        healthcheck_id,
     })
 }
 

--- a/src/distributor.rs
+++ b/src/distributor.rs
@@ -66,10 +66,11 @@ impl Distributor {
         let bar = ProgressBar::new(blocks);
         for bn in start..=current_bn {
             let healthcheck_id = get_config().healthcheck_id.clone();
-            tokio::spawn(async move {
-                ping_healthcheck(healthcheck_id.as_deref()).await;
-            });
-
+            if healthcheck_id.is_some() {
+                tokio::spawn(async move {
+                    ping_healthcheck(healthcheck_id.as_deref()).await;
+                });
+            }
             if let Some(block) = self.provider.get_block(bn.into(), Hashes).await? {
                 if check_if_target(&block.header, self.fee_recipient) {
                     poll_proof_and_distribute(
@@ -100,10 +101,11 @@ impl Distributor {
         let handle = tokio::spawn(async move {
             while let Some(header) = stream.next().await {
                 let healthcheck_id = get_config().healthcheck_id.clone();
-                tokio::spawn(async move {
-                    ping_healthcheck(healthcheck_id.as_deref()).await;
-                });
-
+                if healthcheck_id.is_some() {
+                    tokio::spawn(async move {
+                        ping_healthcheck(healthcheck_id.as_deref()).await;
+                    });
+                }
                 let should_distribute = check_if_target(&header, fee_recipient);
                 tracing::info!(bn=?header.number, fee_recipient=?header.beneficiary, ?should_distribute, "Received block");
                 if should_distribute {

--- a/src/healthcheck.rs
+++ b/src/healthcheck.rs
@@ -1,0 +1,28 @@
+use healthchecks::ping::get_client;
+
+/// Sends a ping to healthchecks.io with a success signal
+/// Does nothing if healthcheck_id is not set
+
+pub async fn ping_healthcheck(healthcheck_id: Option<&str>) {
+    // If no healthcheck_id is provided, do nothing
+    let Some(id) = healthcheck_id else {
+        return;
+    };
+
+    // Create the healthchecks client
+    let client = match get_client(id) {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::warn!("Failed to create healthcheck client: {}", e);
+            return;
+        }
+    };
+
+    // Send the ping
+    let success = client.report_success();
+    if success {
+        tracing::debug!("Healthcheck ping sent successfully");
+    } else {
+        tracing::warn!("Healthcheck ping failed to send");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,9 @@ mod config;
 mod contract;
 mod distribute;
 mod distributor;
+mod healthcheck;
 mod types;
 mod utils;
-mod healthcheck;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod distribute;
 mod distributor;
 mod types;
 mod utils;
+mod healthcheck;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {


### PR DESCRIPTION
Not sure if you (or anyone else) will find this valuable, it's pretty specific and I'm certainly no rust developer.

Feature to have berastribute to send a ping to healthchecks.io on every block processed as a dead-mans switch to ensure process is active and processing blocks.  This is probably overkill and would be better served by a side-car or health-check endpoint , but since we use healthchecks.io for processes like this...

Added:
- healthcheck rust library with simple `ping` on every block processed
- New config.toml item `healthcheck_id` with the ID procured at healthcheck.io
- If above variable doesn't exist, then this addition does nothing.

Improvements that could be done that I'm not qualified to do:
- Replace this with an in-binary /health endpoint of some sort that can be queried with maybe the current height and health status, and maybe even the balance of funds on the sending wallet
- Generalize this beyond healthchecks.io to allow a generic "url" to ping.
- Remove the ping every block and slow it down to every 100 blocks or 15 minutes.

Anyway, appreciate the tool!
